### PR TITLE
Add ignoredProjectPaths setting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,6 +87,17 @@ function installCompiler() {
 }
 
 /**
+ * @param {string} projectPath
+ * @return {bool} the project path has been explicitly disabled
+ */
+function shouldIgnoreProjectPath(projectPath) {
+  const ignoredPaths = atom.config.get('ide-rust.ignoredProjectPaths')
+  return ignoredPaths && ignoredPaths.split(',')
+    .map(path => path.trim().replace(/[/\\]*$/, ''))
+    .some(path => path === projectPath.trim().replace(/[/\\]*$/, ''))
+}
+
+/**
  * @param {string} toolchain
  * @return {Promise<string>} `rustc --print sysroot` stdout
  */
@@ -270,6 +281,7 @@ class RustLanguageClient extends AutoLanguageClient {
         description: 'Configuration default sent to all Rls instances, overridden by project rls.toml configuration',
         type: 'object',
         collapsed: false,
+        order: 3,
         properties: {
           allTargets: {
             title: "Check All Targets",
@@ -288,6 +300,12 @@ class RustLanguageClient extends AutoLanguageClient {
             enum: ["On", "Opt-in", "Off", "Rls Default"]
           }
         }
+      },
+      ignoredProjectPaths: {
+        description: 'Disables ide-rust functionality on a comma-separated list of project paths.',
+        type: 'string',
+        default: '',
+        order: 999
       }
     }
   }
@@ -575,6 +593,13 @@ class RustLanguageClient extends AutoLanguageClient {
   }
 
   async startServerProcess(projectPath) {
+    if (shouldIgnoreProjectPath(projectPath)) {
+      console.warn("ide-rust disabled on", projectPath)
+      // It's a bit ugly to just return as it causes some upstream error logs
+      // But there doesn't seem to be a better option for path disabling at the moment
+      return
+    }
+
     if (!this._periodicUpdateChecking) {
       // if haven't started periodic checks for updates yet start now
       let periodicUpdateTimeoutId


### PR DESCRIPTION
Adds new setting to disable ide-rust on certain projects.
![ignored-paths](https://user-images.githubusercontent.com/2331607/42112256-249325b0-7bdf-11e8-8c3b-a09f6e0932a1.png)

The implementation to return a null-promise is a bit crude, but I can see a better option and this does the job with minimal code - easy to improve later.

Resolves #87

