### PR TITLE
Include process.env in rustup execution env

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,9 @@ const PERIODIC_UPDATE_CHECK_MILLIS = 6 * 60 * 60 * 1000
 
 async function exec(command) {
   return new Promise((resolve, reject) => {
-    cp.exec(command, { env: { PATH: envPath() } }, (err, stdout, stderr) => {
+    const env = process.env
+    env.PATH = envPath()
+    cp.exec(command, { env }, (err, stdout, stderr) => {
       if (err != null) {
         reject(err)
         return


### PR DESCRIPTION
This may help #89, but also makes sense to execute rustup in the same way in all cases.