### PR TITLE
Fix dated nightly search

### DIFF
--- a/lib/dist-fetch.js
+++ b/lib/dist-fetch.js
@@ -5,6 +5,14 @@ const datedNightlyHasRlsCache = new Map()
 const DATED_REGEX = /(^[^-]+)-(\d{4,}-\d{2}-\d{2})$/
 
 /**
+ * @param {string} manifest toml
+ * @return {boolean}
+ */
+function manifest_includes_rls(manifest) {
+  return manifest.includes('rls-preview') && !manifest.includes('[pkg.rls-preview]\nversion = ""')
+}
+
+/**
  * @param {Date|string} date
  * @param {string=} channel defaults to `nightly`
  * @return {Promise<string>} toolchain name
@@ -22,7 +30,7 @@ async function checkDatedDistHasRls(date, channel='nightly') {
         let body = ""
         res.on("data", data => {
           body += data
-          if (body.includes('rls-preview')) resolve(cacheKey)
+          if (manifest_includes_rls(body)) resolve(cacheKey)
         })
         res.on("end", () => reject(new Error("no 'rls-preview'")))
       })
@@ -82,9 +90,9 @@ async function fetchLatestDist({ toolchain, currentVersion="none" }) {
         if (!rustcInfo) return reject(new Error('could not split channel toml output'))
         let rustcVersion = require('toml').parse(rustcInfo[1]).pkg.rustc.version.trim()
         resolve(
-          !currentVersion.trim().endsWith(rustcVersion) &&
-          body.includes('rls-preview') &&
-          `rustc ${rustcVersion}`
+          !currentVersion.trim().endsWith(rustcVersion)
+          && manifest_includes_rls(body)
+          && `rustc ${rustcVersion}`
         )
       })
     })


### PR DESCRIPTION
Today's nightly does not include rls, but the manifest format has changed so that the check that the manifest contains `rls-preview` no longer works.

Now the manifest has
```
...
[pkg.rls-preview]
version = ""
[pkg.rls-preview.target.aarch64-unknown-linux-gnu]
available = false

[pkg.rls-preview.target.arm-unknown-linux-gnueabi]
available = false

[pkg.rls-preview.target.arm-unknown-linux-gnueabihf]
available = false

[pkg.rls-preview.target.armv7-unknown-linux-gnueabihf]
available = false

[pkg.rls-preview.target.i686-apple-darwin]
available = false

[pkg.rls-preview.target.i686-pc-windows-gnu]
available = false
...
```

This change requires the manifest contain rls, and **not** contain `[pkg.rls-preview]\nversion = ""`.  This works for the moment, and is backward compatible with the old manifest format.