### PR TITLE
Add more explicit documentation for non-root crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ members = [
 ]
 ```
 
+Even if you only have a single crate in your Atom project, RLS can only detect it if you
+have a root `Cargo.toml`. If your project is setup such that you have one or more crate nested
+in folders under the root, you can add a root `Cargo.toml` file and setup a Cargo workspace that
+includes all the crates in the project:
+```toml
+# Cargo.toml
+[workspace]
+members = [
+    "foo/bar/rust_foo",
+]
+```
+
 ## Overriding Rls
 The Rls command can be specified manually, for example to run from local source code:
 ```cson


### PR DESCRIPTION
This PR adds more explicit documentation for how to handle Atom projects that have Rust crates nested within the project (i.e. not at the root of the project). The multi-crate documentation already provided instructions on how to handle this case, but it was not immediately clear to me that the instructions still applied to a project with only one non-root crate. This addition should make it easier for new users to figure out what they need to do, or at least easier to point them in the right direction when they have questions.

Resolves #100 