### PR TITLE
Default add rls::build=info to RUST_LOG

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,7 +139,7 @@ async function serverEnv(toolchain) {
   env.RUST_BACKTRACE = env.RUST_BACKTRACE || "1"
 
   if (!env.RUST_LOG && atom.config.get('core.debugLSP')) {
-    env.RUST_LOG = 'rls=warn'
+    env.RUST_LOG = 'rls=warn,rls::build=info'
   }
 
   if (toolchain) {


### PR DESCRIPTION
Shows build time info in console when `atom.config.set('core.debugLSP', true)`

![](https://user-images.githubusercontent.com/2331607/46488596-063a4180-c7fb-11e8-895d-aa18c3696619.png)

Introduced to rls in https://github.com/rust-lang-nursery/rls/pull/1072, so should soon be in future releases.