### PR TITLE
Typo fix in warning message for unavailable toolchain

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -424,7 +424,7 @@ class RustLanguageClient extends AutoLanguageClient {
    */
   async _handleMissingToolchainMissingRls(toolchain) {
     const note = {
-      description: '**Warning**: This toolchain is unavilable or missing Rls.',
+      description: '**Warning**: This toolchain is unavailable or missing RLS.',
       buttons: [{
         text: 'Configure',
         onDidClick: () => atom.workspace.open('atom://config/packages/ide-rust')


### PR DESCRIPTION
Replace "unavilable" with "unavailable." Also capitalized RLS in this message.

ide-rust is great!